### PR TITLE
Re-implement serialization methods `save` and `restore` to address new MLJ interface changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 MLJModelInterface = "0.3.5, 0.4, 1"
 Tables = "1.0.5"
 XGBoost = "1.1.1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -17,9 +17,8 @@ julia = "1.3"
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
-MLJSerialization = "17bed46d-0ab5-4cd4-b792-a5c4b8547c6d"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Distributions", "MLJBase", "MLJSerialization", "StableRNGs", "Test"]
+test = ["Distributions", "MLJBase", "StableRNGs", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJXGBoostInterface"
 uuid = "54119dfa-1dab-4055-a167-80440f4f7a91"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"


### PR DESCRIPTION
This PR needs:

- [x] release of MLJBase 0.20

In this PR we:

- (**breaking**) Re-implement the `save` and `restore` methods supporting serialization, to address MLJ API changes at https://github.com/JuliaAI/MLJBase.jl/pull/733. These changes are not backwards compatible: to restore models serialised using MLJXGBoostInterface < 0.2, you will need a version of MLJXGBoostInterface < 0.2 loaded. 

(tests passing locally for me with this branch of MLJBase: https://github.com/JuliaAI/MLJBase.jl/tree/for-a-0-point-20-release)