### PR TITLE
Bump XGBoost.jl to v1.5.2, Tables.jl to 1.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [compat]
 MLJModelInterface = "0.3.5, 0.4, 1"
-Tables = "1.0.5"
-XGBoost = "1.1.1"
+Tables = "1.7"
+XGBoost = "1.5.2"
 julia = "1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Repository implementing MLJ interface for
 [XGBoost](https://github.com/JuliaStats/XGBoost.jl) models.
 
 
-[![Build Status](https://github.com/alan-turing-institute/MLJXGBoostInterface.jl/workflows/CI/badge.svg)](https://github.com/alan-turing-institute/MLJXGBoostInterface.jl/actions)
-[![Coverage](http://codecov.io/github/alan-turing-institute/MLJXGBoostInterface.jl/coverage.svg?branch=master)](https://codecov.io/gh/alan-turing-institute/MLJXGBoostInterface.jl)
+[![Build Status](https://github.com/JuliaAI/MLJXGBoostInterface.jl/workflows/CI/badge.svg)](https://github.com/JuliaAI/MLJXGBoostInterface.jl/actions)
+[![Coverage](http://codecov.io/github/JuliaAI/MLJXGBoostInterface.jl/coverage.svg?branch=master)](https://codecov.io/gh/JuliaAI/MLJXGBoostInterface.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)


### PR DESCRIPTION
Updated XGBoost.jl to the latest version, and noticed Tables.jl also was on an old version. The Build Status and Coverage links in the readme were also updated