### PR TITLE
fix issue #17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.0"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -618,7 +618,7 @@ function MMI.fit(model::XGBoostClassifier
 
     if(num_class==2)
         objective="binary:logistic"
-        y_plain = convert(Array{Bool}, y_plain_)
+        y_plain_ = convert(Array{Bool}, y_plain_)
     else
         objective="multi:softprob"
     end

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -12,6 +12,7 @@ const MMI = MLJModelInterface
 import Tables: schema
 
 import XGBoost
+import SparseArrays
 
 # helper for feature importances:
 # XGBoost used "f
@@ -223,6 +224,11 @@ function MMI.clean!(model::XGBoostRegressor)
     return warning
 end
 
+# For `XGBoost.DMatrix(Xmatrix, y)` `Xmatrix` must either be a julia `Array` or
+# a `SparseMatrixCSC` while `y` must be a `Vector` 
+_to_array(x::Union{Array, SparseArrays.SparseMatrixCSC}) = x
+_to_array(x::AbstractArray) = copyto!(similar(Array{eltype(x)}, axes(x)), x) 
+
 function MMI.fit(model::XGBoostRegressor
              , verbosity::Int
              , X
@@ -230,8 +236,8 @@ function MMI.fit(model::XGBoostRegressor
 
              silent =
                  verbosity > 0 ?  false : true
-    Xmatrix = MMI.matrix(X)
-    dm = XGBoost.DMatrix(Xmatrix,label=y)
+    Xmatrix = _to_array(MMI.matrix(X))
+    dm = XGBoost.DMatrix(Xmatrix, label=_to_array(y))
 
     objective =
         model.objective in ["linear", "gamma", "tweedie"] ?
@@ -259,7 +265,7 @@ end
 function MMI.predict(model::XGBoostRegressor
         , fitresult
         , Xnew)
-    Xmatrix = MMI.matrix(Xnew)
+    Xmatrix = _to_array(MMI.matrix(Xnew))
     return XGBoost.predict(fitresult, Xmatrix)
 end
 
@@ -417,8 +423,8 @@ function MMI.fit(model::XGBoostCount
 
     silent = verbosity > 0 ?  false : true
 
-    Xmatrix = MMI.matrix(X)
-    dm = XGBoost.DMatrix(Xmatrix,label=y)
+    Xmatrix = _to_array(MMI.matrix(X))
+    dm = XGBoost.DMatrix(Xmatrix, label=_to_array(y))
 
     seed =
         model.seed == -1 ? generate_seed() : model.seed
@@ -439,7 +445,7 @@ end
 function MMI.predict(model::XGBoostCount
         , fitresult
         , Xnew)
-    Xmatrix = MMI.matrix(Xnew)
+    Xmatrix = _to_array(MMI.matrix(Xnew))
     return XGBoost.predict(fitresult, Xmatrix)
 end
 
@@ -594,7 +600,7 @@ function MMI.fit(model::XGBoostClassifier
                      , verbosity::Int     #> must be here even if unsupported in pkg
                      , X
                      , y)
-    Xmatrix = MMI.matrix(X)
+    Xmatrix = _to_array(MMI.matrix(X))
 
     a_target_element = y[1] # a CategoricalValue or CategoricalString
     num_class = length(MMI.classes(a_target_element))
@@ -608,14 +614,16 @@ function MMI.fit(model::XGBoostClassifier
         eval_metric = "mlogloss"
     end
 
-    y_plain = MMI.int(y) .- 1 # integer relabeling should start at 0
+    y_plain_ = MMI.int(y) .- 1 # integer relabeling should start at 0
 
     if(num_class==2)
         objective="binary:logistic"
-        y_plain = convert(Array{Bool}, y_plain)
+        y_plain = convert(Array{Bool}, y_plain_)
     else
         objective="multi:softprob"
     end
+    
+    y_plain = _to_array(y_plain_)
 
     silent =
         verbosity > 0 ?  false : true
@@ -655,7 +663,7 @@ function MMI.predict(model::XGBoostClassifier
     decode = MMI.decoder(a_target_element)
     classes = MMI.classes(a_target_element)
 
-    Xmatrix = MMI.matrix(Xnew)
+    Xmatrix = _to_array(MMI.matrix(Xnew))
     XGBpredictions = XGBoost.predict(result, Xmatrix)
 
     nlevels = length(classes)


### PR DESCRIPTION
```julia
julia> using MLJBase, MLJXGBoostInterface

julia> X, y = @load_boston;

julia> mach = machine(XGBoostRegressor(), X, y) |> fit!
[ Info: Training machine(XGBoostRegressor(num_round = 100, …), …).
[1]     train-rmse:17.05900715572495230
[2]     train-rmse:12.26368674723081753
[3]     train-rmse:8.93114637343270878
...
...
[93]    train-rmse:0.04849035713610544
[94]    train-rmse:0.04486228273785487
[95]    train-rmse:0.04335564162769343
[96]    train-rmse:0.04153491165602938
[97]    train-rmse:0.03993580825322041
[98]    train-rmse:0.03791545853534439
[99]    train-rmse:0.03580553836662091
[100]   train-rmse:0.03459588736647584
Machine trained 1 time; caches data
  model: XGBoostRegressor(num_round = 100, …)
  args:
    1:  Source @485 ⏎ `Table{AbstractVector{Continuous}}`
    2:  Source @350 ⏎ `AbstractVector{Continuous}`
```