### PR TITLE
elminate code duplication to make this much easier to maintain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJXGBoostInterface"
 uuid = "54119dfa-1dab-4055-a167-80440f4f7a91"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 [compat]
 MLJModelInterface = "0.3.5, 0.4, 1"
 Tables = "1.0.5"
-XGBoost = "2"
+XGBoost = "2.0.1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJXGBoostInterface"
 uuid = "54119dfa-1dab-4055-a167-80440f4f7a91"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
@@ -12,14 +12,15 @@ XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 [compat]
 MLJModelInterface = "0.3.5, 0.4, 1"
 Tables = "1.0.5"
-XGBoost = "1.1.1"
+XGBoost = "2"
 julia = "1.6"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+MLJTestIntegration = "697918b4-fdc1-4f9e-8ff9-929724cee270"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Distributions", "MLJBase", "StableRNGs", "Test"]
+test = ["Distributions", "MLJBase", "MLJTestIntegration", "StableRNGs", "Test"]

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -135,11 +135,13 @@ function MMI.fit(model::XGBoostClassifier
     nclass = length(MMI.classes(a_target_element))
 
     objective = nclass == 2 ? "binary:logistic" : "multi:softprob"
+    # confusingly, xgboost only wants this set if using multi:softprob
+    num_class = nclass == 2 ? (;) : (num_class=nclass,)
 
     # libxgboost wants float labels
     dm = DMatrix(MMI.matrix(X), float(MMI.int(y) .- 1))
 
-    b = xgboost(dm; kwargs(model, verbosity, objective)..., num_class=nclass)
+    b = xgboost(dm; kwargs(model, verbosity, objective)..., num_class...)
     fr = (b, a_target_element)
 
     (fr, nothing, _getreport(b, model))

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -3,16 +3,18 @@ module MLJXGBoostInterface
 export XGBoostRegressor, XGBoostClassifier, XGBoostCount
 
 import MLJModelInterface
-import MLJModelInterface: Table, Continuous, Count, Finite, OrderedFactor,
-    Multiclass
+using MLJModelInterface: Table, Continuous, Count, Finite, OrderedFactor, Multiclass
 
-const PKG="MLJXGBoostInterface"
+const PKG = "MLJXGBoostInterface"
 const MMI = MLJModelInterface
 
-import Tables: schema
+using Base: @kwdef
+using Tables: schema
 
 import XGBoost
 import SparseArrays
+
+const Maybe{T} = Union{Nothing,T}
 
 # helper for feature importances:
 # XGBoost used "f
@@ -22,99 +24,11 @@ function named_importance(fi::XGBoost.FeatureImportance, features)
     return XGBoost.FeatureImportance(new_fname, fi.gain, fi.cover, fi.freq)
 end
 
-
-# TODO: Why do we need this?
-generate_seed() = mod(round(Int, time()*1e8), 10000)
-
-# helper to preprocess hyper-parameters:
-function kwargs(model, silent, seed, objective, eval_metric)
-
-    kwargs = (booster = model.booster
-              , silent = silent
-              , disable_default_eval_metric = model.disable_default_eval_metric
-              , eta = model.eta
-              , gamma = model.gamma
-              , max_depth = model.max_depth
-              , min_child_weight = model.min_child_weight
-              , max_delta_step = model.max_delta_step
-              , subsample = model.subsample
-              , colsample_bytree = model.colsample_bytree
-              , colsample_bylevel = model.colsample_bylevel
-              , colsample_bynode = model.colsample_bynode
-              , lambda = model.lambda
-              , alpha = model.alpha
-              , tree_method = model.tree_method
-              , sketch_eps = model.sketch_eps
-              , scale_pos_weight = model.scale_pos_weight
-              , refresh_leaf = model.refresh_leaf
-              , process_type = model.process_type
-              , grow_policy = model.grow_policy
-              , max_leaves = model.max_leaves
-              , max_bin = model.max_bin
-              , predictor = model.predictor
-              , sample_type = model.sample_type
-              , normalize_type = model.normalize_type
-              , rate_drop = model.rate_drop
-              , one_drop = model.one_drop
-              , skip_drop = model.skip_drop
-              , feature_selector = model.feature_selector
-              , top_k = model.top_k
-              , tweedie_variance_power = model.tweedie_variance_power
-              , objective = objective
-              , base_score = model.base_score
-              , eval_metric=eval_metric
-              , seed = seed
-              , nthread = model.nthread) # MD
-
-    if model.updater != "auto"
-        return merge(kwargs, (updater=model.updater,))
-    else
-        return kwargs
-    end
-end
+abstract type XGBoostAbstractRegressor <: MMI.Deterministic end
+abstract type XGBoostAbstractClassifier <: MMI.Probabilistic end
 
 
 ## REGRESSOR
-
-mutable struct XGBoostRegressor <:MMI.Deterministic
-    num_round::Int
-    booster::String
-    disable_default_eval_metric::Int
-    eta::Float64
-    gamma::Float64
-    max_depth::Int
-    min_child_weight::Float64
-    max_delta_step::Float64
-    subsample::Float64
-    colsample_bytree::Float64
-    colsample_bylevel::Float64
-    colsample_bynode::Float64
-    lambda::Float64
-    alpha::Float64
-    tree_method::String
-    sketch_eps::Float64
-    scale_pos_weight::Float64
-    updater::String
-    refresh_leaf::Union{Int,Bool}
-    process_type::String
-    grow_policy::String
-    max_leaves::Int
-    max_bin::Int
-    predictor::String
-    sample_type::String
-    normalize_type::String
-    rate_drop::Float64
-    one_drop
-    skip_drop::Float64
-    feature_selector::String
-    top_k::Int
-    tweedie_variance_power::Float64
-    objective
-    base_score::Float64
-    eval_metric
-    seed::Int
-    nthread::Int # MD
-end
 
 """
     XGBoostRegressor(; objective="linear", seed=0, kwargs...)
@@ -129,88 +43,59 @@ For a time-dependent random seed, use `seed=-1`.
 See also: XGBoostCount, XGBoostClassifier
 
 """
-function XGBoostRegressor(
-    ;num_round=100
-    ,booster="gbtree"
-    ,disable_default_eval_metric=0
-    ,eta=0.3
-    ,gamma=0
-    ,max_depth=6
-    ,min_child_weight=1
-    ,max_delta_step=0
-    ,subsample=1
-    ,colsample_bytree=1
-    ,colsample_bylevel=1
-    ,colsample_bynode=1
-    ,lambda=1
-    ,alpha=0
-    ,tree_method="auto"
-    ,sketch_eps=0.03
-    ,scale_pos_weight=1
-    ,updater="auto"
-    ,refresh_leaf=1
-    ,process_type="default"
-    ,grow_policy="depthwise"
-    ,max_leaves=0
-    ,max_bin=256
-    ,predictor="cpu_predictor" #> gpu version not currently working with Julia, maybe remove completely?
-    ,sample_type="uniform"
-    ,normalize_type="tree"
-    ,rate_drop=0.0
-    ,one_drop=0
-    ,skip_drop=0.0
-    ,feature_selector="cyclic"
-    ,top_k=0
-    ,tweedie_variance_power=1.5
-    ,objective="reg:squarederror"
-    ,base_score=0.5
-    ,eval_metric="rmse"
-    ,seed=0
-    ,nthread = 1)
+@kwdef mutable struct XGBoostRegressor <: XGBoostAbstractRegressor
+    num_round::Int = 100  # this must be provided since XGBoost.jl doesn't provide it
+    booster::Maybe{String} = nothing
+    disable_default_eval_metric::Maybe{Int} = nothing
+    eta::Maybe{Float64} = nothing
+    num_parallel_tree::Maybe{Int} = nothing
+    gamma::Maybe{Float64} = nothing
+    max_depth::Maybe{Int} = nothing
+    min_child_weight::Maybe{Float64} = nothing
+    max_delta_step::Maybe{Float64} = nothing
+    subsample::Maybe{Float64} = nothing
+    colsample_bytree::Maybe{Float64} = nothing
+    colsample_bylevel::Maybe{Float64} = nothing
+    colsample_bynode::Maybe{Float64} = nothing
+    lambda::Maybe{Float64} = nothing
+    alpha::Maybe{Float64} = nothing
+    tree_method::Maybe{String} = nothing
+    sketch_eps::Maybe{Float64} = nothing
+    scale_pos_weight::Maybe{Float64} = nothing
+    updater::Maybe{Float64} = nothing
+    refresh_leaf::Maybe{Union{Int,Bool}} = 1
+    process_type::Maybe{String} = nothing
+    grow_policy::Maybe{String} = nothing
+    max_leaves::Maybe{Int} = nothing
+    max_bin::Maybe{Int} = nothing
+    predictor::Maybe{String} = "cpu_predictor"
+    sample_type::Maybe{String} = nothing
+    normalize_type::Maybe{String} = nothing
+    rate_drop::Maybe{Float64} = nothing
+    one_drop::Maybe{Union{Int,Bool}} = nothing
+    skip_drop::Maybe{Float64} = nothing
+    feature_selector::Maybe{String} = nothing
+    top_k::Maybe{Int} = nothing
+    tweedie_variance_power::Maybe{Float64} = nothing
+    objective = "reg:squarederror"
+    base_score::Maybe{Float64} = nothing
+    eval_metric = "rmse"
+    seed::Maybe{Int} = nothing
+    nthread::Maybe{Int} = nothing
 
-    model = XGBoostRegressor(
-    num_round
-    ,booster
-    ,disable_default_eval_metric
-    ,eta
-    ,gamma
-    ,max_depth
-    ,min_child_weight
-    ,max_delta_step
-    ,subsample
-    ,colsample_bytree
-    ,colsample_bylevel
-    ,colsample_bynode
-    ,lambda
-    ,alpha
-    ,tree_method
-    ,sketch_eps
-    ,scale_pos_weight
-    ,updater
-    ,refresh_leaf
-    ,process_type
-    ,grow_policy
-    ,max_leaves
-    ,max_bin
-    ,predictor #> gpu version not currently working with Julia, maybe remove completely?
-    ,sample_type
-    ,normalize_type
-    ,rate_drop
-    ,one_drop
-    ,skip_drop
-    ,feature_selector
-    ,top_k
-    ,tweedie_variance_power
-    ,objective
-    ,base_score
-    ,eval_metric
-    ,seed
-    ,nthread) #MD
+    XGBoostRegressor(a...) = _constructor_checks(new(a...))
+end
 
-     message = MMI.clean!(model)
-     isempty(message) || @warn message
+function _fix_objective(obj)
+    obj ∈ ("linear", "gamma", "tweedie") ? "reg:"*obj : obj
+end
 
-    return model
+function kwargs(model, verbosity::Integer, obj, eval=nothing)
+    fn = fieldnames(typeof(model))
+    o = NamedTuple(n=>getfield(model, n) for n ∈ fn if !isnothing(getfield(model, n)))
+    o = merge(o, (silent=(verbosity == 0),))
+    isnothing(eval) || (o = merge(o, (eval=eval,)))
+    merge(o, (objective=_fix_objective(obj),))
 end
 
 function MMI.clean!(model::XGBoostRegressor)
@@ -228,92 +113,36 @@ function MMI.clean!(model::XGBoostRegressor)
     return warning
 end
 
+function _constructor_checks(model)
+    msg = MMI.clean(model)
+    isempty(msg) || @warn msg
+    model
+end
+
 # For `XGBoost.DMatrix(Xmatrix, y)` `Xmatrix` must either be a julia `Array` or
 # a `SparseMatrixCSC` while `y` must be a `Vector` 
 _to_array(x::Union{Array, SparseArrays.SparseMatrixCSC}) = x
 _to_array(x::AbstractArray) = copyto!(similar(Array{eltype(x)}, axes(x)), x) 
 
-function MMI.fit(model::XGBoostRegressor
-             , verbosity::Int
-             , X
-             , y)
-
-             silent =
-                 verbosity > 0 ?  false : true
-    Xmatrix = _to_array(MMI.matrix(X))
-    dm = XGBoost.DMatrix(Xmatrix, label=_to_array(y))
-
-    objective =
-        model.objective in ["linear", "gamma", "tweedie"] ?
-            "reg:"*model.objective : model.objective
-
-    seed =
-        model.seed == -1 ? generate_seed() : model.seed
-
-
-    fitresult = XGBoost.xgboost(dm, model.num_round;
-                                kwargs(model, silent, seed, objective,model.eval_metric)...)
-
-    features = schema(X).names
-    importances = [named_importance(fi, features) for
-                   fi in XGBoost.importance(fitresult)]
-    cache = nothing
-
-    report = (feature_importances=importances, )
-
-    return fitresult, cache, report
-
+function importances(X, r)
+    fs = schema(X).names
+    [named_importance(fi, fs) for fi ∈ XGBoost.importance(r)]
 end
 
+function MMI.fit(model::XGBoostAbstractRegressor, verbosity::Integer, X, y)
+    Xmatrix = _to_array(MMI.matrix(X))
+    dm = DMatrix(Xmatrix, label=_to_array(y))
 
-function MMI.predict(model::XGBoostRegressor
-        , fitresult
-        , Xnew)
+    r = xgboost(dm, model.num_round; kwargs(model, verbosity, obj)...)
+
+    report = (feature_importances=importances(X, r), )
+
+    (r, nothing, report)
+end
+
+function MMI.predict(model::XGBoostAbstractRegressor, fitresult, Xnew)
     Xmatrix = _to_array(MMI.matrix(Xnew))
     return XGBoost.predict(fitresult, Xmatrix)
-end
-
-
-## COUNT REGRESSOR
-
-mutable struct XGBoostCount <:MMI.Deterministic
-    num_round::Int
-    booster::String
-    disable_default_eval_metric::Int
-    eta::Float64
-    gamma::Float64
-    max_depth::Int
-    min_child_weight::Float64
-    max_delta_step::Float64
-    subsample::Float64
-    colsample_bytree::Float64
-    colsample_bylevel::Float64
-    colsample_bynode::Float64
-    lambda::Float64
-    alpha::Float64
-    tree_method::String
-    sketch_eps::Float64
-    scale_pos_weight::Float64
-    updater::String
-    refresh_leaf::Union{Int,Bool}
-    process_type::String
-    grow_policy::String
-    max_leaves::Int
-    max_bin::Int
-    predictor::String
-    sample_type::String
-    normalize_type::String
-    rate_drop::Float64
-    one_drop
-    skip_drop::Float64
-    feature_selector::String
-    top_k::Int
-    tweedie_variance_power::Float64
-    objective
-    base_score::Float64
-    eval_metric
-    seed::Int
-    nthread::Int
 end
 
 
@@ -329,174 +158,57 @@ For a time-dependent random seed, use `seed=-1`.
 See also: XGBoostRegressor, XGBoostClassifier
 
 """
-function XGBoostCount(
-    ;num_round=100
-    ,booster="gbtree"
-    ,disable_default_eval_metric=0
-    ,eta=0.3
-    ,gamma=0
-    ,max_depth=6
-    ,min_child_weight=1
-    ,max_delta_step=0
-    ,subsample=1
-    ,colsample_bytree=1
-    ,colsample_bylevel=1
-    ,colsample_bynode=1,
-    ,lambda=1
-    ,alpha=0
-    ,tree_method="auto"
-    ,sketch_eps=0.03
-    ,scale_pos_weight=1
-    ,updater="auto"
-    ,refresh_leaf=1
-    ,process_type="default"
-    ,grow_policy="depthwise"
-    ,max_leaves=0
-    ,max_bin=256
-    ,predictor="cpu_predictor" #> gpu version not currently working with Julia, maybe remove completely?
-    ,sample_type="uniform"
-    ,normalize_type="tree"
-    ,rate_drop=0.0
-    ,one_drop=0
-    ,skip_drop=0.0
-    ,feature_selector="cyclic"
-    ,top_k=0
-    ,tweedie_variance_power=1.5
-    ,objective="count:poisson"
-    ,base_score=0.5
-    ,eval_metric="rmse"
-    ,seed=0
-    ,nthread = 1)
+@kwdef mutable struct XGBoostCount <:MMI.Deterministic
+    num_round::Int = 100  # this must be provided since XGBoost.jl doesn't provide it
+    booster::Maybe{String} = nothing
+    disable_default_eval_metric::Maybe{Int} = nothing
+    eta::Maybe{Float64} = nothing
+    num_parallel_tree::Maybe{Int} = nothing
+    gamma::Maybe{Float64} = nothing
+    max_depth::Maybe{Int} = nothing
+    min_child_weight::Maybe{Float64} = nothing
+    max_delta_step::Maybe{Float64} = nothing
+    subsample::Maybe{Float64} = nothing
+    colsample_bytree::Maybe{Float64} = nothing
+    colsample_bylevel::Maybe{Float64} = nothing
+    colsample_bynode::Maybe{Float64} = nothing
+    lambda::Maybe{Float64} = nothing
+    alpha::Maybe{Float64} = nothing
+    tree_method::Maybe{String} = nothing
+    sketch_eps::Maybe{Float64} = nothing
+    scale_pos_weight::Maybe{Float64} = nothing
+    updater::Maybe{Float64} = nothing
+    refresh_leaf::Maybe{Union{Int,Bool}} = 1
+    process_type::Maybe{String} = nothing
+    grow_policy::Maybe{String} = nothing
+    max_leaves::Maybe{Int} = nothing
+    max_bin::Maybe{Int} = nothing
+    predictor::Maybe{String} = "cpu_predictor"
+    sample_type::Maybe{String} = nothing
+    normalize_type::Maybe{String} = nothing
+    rate_drop::Maybe{Float64} = nothing
+    one_drop::Maybe{Union{Int,Bool}} = nothing
+    skip_drop::Maybe{Float64} = nothing
+    feature_selector::Maybe{String} = nothing
+    top_k::Maybe{Int} = nothing
+    tweedie_variance_power::Maybe{Float64} = nothing
+    objective = "count:poisson"
+    base_score::Maybe{Float64} = nothing
+    eval_metric = "rmse"
+    seed::Maybe{Int} = nothing
+    nthread::Maybe{Int} = nothing
 
-    model = XGBoostCount(
-    num_round
-    ,booster
-    ,disable_default_eval_metric
-    ,eta
-    ,gamma
-    ,max_depth
-    ,min_child_weight
-    ,max_delta_step
-    ,subsample
-    ,colsample_bytree
-    ,colsample_bylevel
-    ,colsample_bynode
-    ,lambda
-    ,alpha
-    ,tree_method
-    ,sketch_eps
-    ,scale_pos_weight
-    ,updater
-    ,refresh_leaf
-    ,process_type
-    ,grow_policy
-    ,max_leaves
-    ,max_bin
-    ,predictor #> gpu version not currently working with Julia, maybe remove completely?
-    ,sample_type
-    ,normalize_type
-    ,rate_drop
-    ,one_drop
-    ,skip_drop
-    ,feature_selector
-    ,top_k
-    ,tweedie_variance_power
-    ,objective
-    ,base_score
-    ,eval_metric
-    ,seed
-    ,nthread)
-
-     message = MMI.clean!(model)
-     isempty(message) || @warn message
-
-    return model
+    XGBoostCount(a...) = _constructor_checks(new(a...))
 end
 
 function MMI.clean!(model::XGBoostCount)
     warning = ""
     if(!(model.objective in ["count:poisson"]))
         warning *= "Changing objective to \"poisson\", "*
-                       "the only supported value. "
+        "the only supported value. "
         model.objective="poisson"
     end
     return warning
-end
-
-function MMI.fit(model::XGBoostCount
-             , verbosity::Int     #> must be here even if unsupported in pkg
-             , X
-             , y)
-
-    silent = verbosity > 0 ?  false : true
-
-    Xmatrix = _to_array(MMI.matrix(X))
-    dm = XGBoost.DMatrix(Xmatrix, label=_to_array(y))
-
-    seed =
-        model.seed == -1 ? generate_seed() : model.seed
-
-    fitresult = XGBoost.xgboost(dm, model.num_round;
-                                kwargs(model, silent, seed, "count:poisson",model.eval_metric)...)
-    features = schema(X).names
-    importances = [named_importance(fi, features) for
-                   fi in XGBoost.importance(fitresult)]
-
-    cache = nothing
-    report = (feature_importances=importances, )
-
-    return fitresult, cache, report
-
-end
-
-function MMI.predict(model::XGBoostCount
-        , fitresult
-        , Xnew)
-    Xmatrix = _to_array(MMI.matrix(Xnew))
-    return XGBoost.predict(fitresult, Xmatrix)
-end
-
-
-## CLASSIFIER
-
-mutable struct XGBoostClassifier <:MMI.Probabilistic
-    num_round::Int
-    booster::String
-    disable_default_eval_metric::Int
-    eta::Float64
-    gamma::Float64
-    max_depth::Int
-    min_child_weight::Float64
-    max_delta_step::Float64
-    subsample::Float64
-    colsample_bytree::Float64
-    colsample_bylevel::Float64
-    colsample_bynode::Float64
-    lambda::Float64
-    alpha::Float64
-    tree_method::String
-    sketch_eps::Float64
-    scale_pos_weight::Float64
-    updater::String
-    refresh_leaf::Union{Int,Bool}
-    process_type::String
-    grow_policy::String
-    max_leaves::Int
-    max_bin::Int
-    predictor::String
-    sample_type::String
-    normalize_type::String
-    rate_drop::Float64
-    one_drop
-    skip_drop::Float64
-    feature_selector::String
-    top_k::Int
-    tweedie_variance_power::Float64
-    objective
-    base_score::Float64
-    eval_metric
-    seed::Int
-    nthread::Int
 end
 
 """
@@ -512,164 +224,103 @@ For a time-dependent random seed, use `seed=-1`.
 See also: XGBoostCount, XGBoostRegressor
 
 """
-function XGBoostClassifier(
-    ;num_round=100
-    ,booster="gbtree"
-    ,disable_default_eval_metric=0
-    ,eta=0.3
-    ,gamma=0
-    ,max_depth=6
-    ,min_child_weight=1
-    ,max_delta_step=0
-    ,subsample=1
-    ,colsample_bytree=1
-    ,colsample_bylevel=1
-    ,colsample_bynode=1
-    ,lambda=1
-    ,alpha=0
-    ,tree_method="auto"
-    ,sketch_eps=0.03
-    ,scale_pos_weight=1
-    ,updater="auto"
-    ,refresh_leaf=1
-    ,process_type="default"
-    ,grow_policy="depthwise"
-    ,max_leaves=0
-    ,max_bin=256
-    ,predictor="cpu_predictor" #> gpu version not currently working with Julia, maybe remove completely?
-    ,sample_type="uniform"
-    ,normalize_type="tree"
-    ,rate_drop=0.0
-    ,one_drop=0
-    ,skip_drop=0.0
-    ,feature_selector="cyclic"
-    ,top_k=0
-    ,tweedie_variance_power=1.5
-    ,objective="automatic"
-    ,base_score=0.5
-    ,eval_metric="mlogloss"
-    ,seed=0
-    ,nthread = 1)
+@kwdef mutable struct XGBoostClassifier <:MMI.Probabilistic
+    num_round::Int = 100  # this must be provided since XGBoost.jl doesn't provide it
+    booster::Maybe{String} = nothing
+    disable_default_eval_metric::Maybe{Int} = nothing
+    eta::Maybe{Float64} = nothing
+    num_parallel_tree::Maybe{Int} = nothing
+    gamma::Maybe{Float64} = nothing
+    max_depth::Maybe{Int} = nothing
+    min_child_weight::Maybe{Float64} = nothing
+    max_delta_step::Maybe{Float64} = nothing
+    subsample::Maybe{Float64} = nothing
+    colsample_bytree::Maybe{Float64} = nothing
+    colsample_bylevel::Maybe{Float64} = nothing
+    colsample_bynode::Maybe{Float64} = nothing
+    lambda::Maybe{Float64} = nothing
+    alpha::Maybe{Float64} = nothing
+    tree_method::Maybe{String} = nothing
+    sketch_eps::Maybe{Float64} = nothing
+    scale_pos_weight::Maybe{Float64} = nothing
+    updater::Maybe{Float64} = nothing
+    refresh_leaf::Maybe{Union{Int,Bool}} = 1
+    process_type::Maybe{String} = nothing
+    grow_policy::Maybe{String} = nothing
+    max_leaves::Maybe{Int} = nothing
+    max_bin::Maybe{Int} = nothing
+    predictor::Maybe{String} = "cpu_predictor"
+    sample_type::Maybe{String} = nothing
+    normalize_type::Maybe{String} = nothing
+    rate_drop::Maybe{Float64} = nothing
+    one_drop::Maybe{Union{Int,Bool}} = nothing
+    skip_drop::Maybe{Float64} = nothing
+    feature_selector::Maybe{String} = nothing
+    top_k::Maybe{Int} = nothing
+    tweedie_variance_power::Maybe{Float64} = nothing
+    objective = "automatic"
+    base_score::Maybe{Float64} = nothing
+    eval_metric = "mlogloss"
+    seed::Maybe{Int} = nothing
+    nthread::Maybe{Int} = nothing
 
-    model = XGBoostClassifier(
-    num_round
-    ,booster
-    ,disable_default_eval_metric
-    ,eta
-    ,gamma
-    ,max_depth
-    ,min_child_weight
-    ,max_delta_step
-    ,subsample
-    ,colsample_bytree
-    ,colsample_bylevel
-    ,colsample_bynode
-    ,lambda
-    ,alpha
-    ,tree_method
-    ,sketch_eps
-    ,scale_pos_weight
-    ,updater
-    ,refresh_leaf
-    ,process_type
-    ,grow_policy
-    ,max_leaves
-    ,max_bin
-    ,predictor #> gpu version not currently working with Julia, maybe remove completely?
-    ,sample_type
-    ,normalize_type
-    ,rate_drop
-    ,one_drop
-    ,skip_drop
-    ,feature_selector
-    ,top_k
-    ,tweedie_variance_power
-    ,objective
-    ,base_score
-    ,eval_metric
-    ,seed
-    ,nthread)
-
-     message = MMI.clean!(model)           #> future proof by including these
-     isempty(message) || @warn message #> two lines even if no clean! defined below
-
-    return model
+    XGBoostClassifier(a...) = _constructor_checks(new(a...))
 end
-
 
 function MMI.clean!(model::XGBoostClassifier)
     warning = ""
     if(!(model.objective =="automatic"))
-            warning *="Changing objective to \"automatic\", the only supported value. "
-            model.objective="automatic"
+        warning *="Changing objective to \"automatic\", the only supported value. "
+        model.objective="automatic"
     end
     return warning
 end
 
 function MMI.fit(model::XGBoostClassifier
-                     , verbosity::Int     #> must be here even if unsupported in pkg
-                     , X
-                     , y)
+                 , verbosity::Int     #> must be here even if unsupported in pkg
+                 , X
+                 , y)
     Xmatrix = _to_array(MMI.matrix(X))
 
     a_target_element = y[1] # a CategoricalValue or CategoricalString
-    num_class = length(MMI.classes(a_target_element))
+    nclass = length(MMI.classes(a_target_element))
 
     # The eval metric is different depending on the class size.
     eval_metric = model.eval_metric
-    if num_class == 2 && eval_metric == "mlogloss"
+    if nclass == 2 && eval_metric == "mlogloss"
         eval_metric = "logloss"
     end
-    if num_class > 2 && eval_metric == "logloss"
+    if nclass > 2 && eval_metric == "logloss"
         eval_metric = "mlogloss"
     end
 
     y_plain_ = MMI.int(y) .- 1 # integer relabeling should start at 0
 
-    if(num_class==2)
-        objective="binary:logistic"
+    if nclass == 2
+        objective = "binary:logistic"
         y_plain_ = convert(Array{Bool}, y_plain_)
     else
-        objective="multi:softprob"
+        objective = "multi:softprob"
     end
-    
+
     y_plain = _to_array(y_plain_)
 
-    silent =
-        verbosity > 0 ?  false : true
+    nclass_arg = nclass == 2 ? (;) : (num_class=nclass,)
 
-    seed =
-        model.seed == -1 ? generate_seed() : model.seed
+    r = xgboost(Xmatrix, label=y_plain, model.num_round;
+                nclass_arg...,
+                kwargs(model, verbosity, objective, eval_metric)...
+               )
+    fr = (result, a_target_element)
 
-    if num_class == 2
-        # XGBoost API requires that num_class is not passed in when n=2.
-        result = XGBoost.xgboost(Xmatrix, label=y_plain, model.num_round;
-                             kwargs(model, silent, seed, objective,eval_metric)...)
-    else
-        result = XGBoost.xgboost(Xmatrix, label=y_plain, model.num_round;
-                                 num_class=num_class,
-                                 kwargs(model, silent, seed, objective,eval_metric)...)
-    end
-    fitresult = (result, a_target_element)
+    report = (feature_importances=importances(X, r), )
 
-    features = schema(X).names
-
-    importances = [named_importance(fi, features) for
-                   fi in XGBoost.importance(result)]
-
-    cache = nothing
-    report = (feature_importances=importances, )
-
-    return fitresult, cache, report
-
+    (fr, nothing, report)
 end
 
 
-function MMI.predict(model::XGBoostClassifier
-        , fitresult
-        , Xnew)
-
-    result, a_target_element = fitresult
+function MMI.predict(model::XGBoostClassifier, fitresult, Xnew)
+    (result, a_target_element) = fitresult
     decode = MMI.decoder(a_target_element)
     classes = MMI.classes(a_target_element)
 
@@ -688,9 +339,7 @@ function MMI.predict(model::XGBoostClassifier
     prediction_probabilities = reshape(XGBpredictions, nlevels, npatterns)
 
     # note we use adjoint of above:
-    predictions = MMI.UnivariateFinite(classes, prediction_probabilities')
-
-    return predictions
+    MMI.UnivariateFinite(classes, prediction_probabilities')
 end
 
 
@@ -750,10 +399,10 @@ end
 const XGBoostInfinite = Union{XGBoostRegressor,XGBoostCount}
 
 MLJModelInterface.save(::XGBoostInfinite, fitresult; kwargs...) =
-    persistent(fitresult)
+persistent(fitresult)
 
 MLJModelInterface.restore(::XGBoostInfinite, serializable_fitresult) =
-                          booster(serializable_fitresult)
+booster(serializable_fitresult)
 
 
 # ## Classifier
@@ -785,22 +434,22 @@ MMI.load_path(::Type{<:XGBoostRegressor}) = "$PKG.XGBoostRegressor"
 MMI.input_scitype(::Type{<:XGBoostRegressor}) = Table(Continuous)
 MMI.target_scitype(::Type{<:XGBoostRegressor}) = AbstractVector{Continuous}
 MMI.docstring(::Type{<:XGBoostRegressor}) =
-    "The XGBoost gradient boosting method, for use with "*
-    "`Continuous` univariate targets. "
+"The XGBoost gradient boosting method, for use with "*
+"`Continuous` univariate targets. "
 
 MMI.load_path(::Type{<:XGBoostCount}) = "$PKG.XGBoostCount"
 MMI.input_scitype(::Type{<:XGBoostCount}) = Table(Continuous)
 MMI.target_scitype(::Type{<:XGBoostCount}) = AbstractVector{Count}
 MMI.docstring(::Type{<:XGBoostCount}) =
-    "The XGBoost gradient boosting method, for use with "*
-    "`Count` univariate targets, using a Poisson objective function. "
+"The XGBoost gradient boosting method, for use with "*
+"`Count` univariate targets, using a Poisson objective function. "
 
 MMI.load_path(::Type{<:XGBoostClassifier}) = "$PKG.XGBoostClassifier"
 MMI.input_scitype(::Type{<:XGBoostClassifier}) = Table(Continuous)
 MMI.target_scitype(::Type{<:XGBoostClassifier}) = AbstractVector{<:Finite}
 MMI.docstring(::Type{<:XGBoostClassifier}) =
-    "The XGBoost gradient boosting method, for use with "*
-    "`Finite` univariate targets (`Multiclass`, "*
-    "`OrderedFactor` and `Binary=Finite{2}`)."
+"The XGBoost gradient boosting method, for use with "*
+"`Finite` univariate targets (`Multiclass`, "*
+"`OrderedFactor` and `Binary=Finite{2}`)."
 
 end # module

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -152,7 +152,7 @@ function MMI.fit(model::XGBoostClassifier
     b = xgboost(dm; kwargs(model, verbosity, objective)..., num_class...)
     fr = (b, a_target_element)
 
-    (fr, nothing, _getreport(b, model))
+    (fr, nothing, (features=_feature_names(X, dm),))
 end
 
 function MMI.predict(model::XGBoostClassifier, fitresult, Xnew)

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -109,8 +109,16 @@ function importances(X, r)
     [named_importance(fi, fs) for fi ∈ XGB.importance(r)]
 end
 
-function _getreport(b::Booster, model)
-    isnothing(model.importance_type) ? (;) : (feature_importances=XGB.importance(b, model.importance_type),)
+function MMI.feature_importances(
+    model::Union{XGBoostAbstractRegressor, XGBoostAbstractClassifier}, 
+    (booster, _), 
+    (features,)
+)
+    importance_dict=XGB.importance(booster, model.importance_type)
+    if length(last(first(importance_dict))) > 1
+        return [features[k] => zero(first(v)) for (k, v) in importance_dict]
+    else
+        return [features[k] => first(v) for (k, v) in importance_dict]
 end
 
 function MMI.fit(model::XGBoostAbstractRegressor, verbosity::Integer, X, y)

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -121,10 +121,20 @@ function MMI.feature_importances(
         return [features[k] => first(v) for (k, v) in importance_dict]
 end
 
+function _feature_names(X, dmatrix)
+    schema = Tables.schema(X)
+     if schema === nothing
+        features = [Symbol("x$j") for j in 1:ncols(dmatrix)]
+    else
+        features = schema.names |> collect
+    end
+    return features
+end
+
 function MMI.fit(model::XGBoostAbstractRegressor, verbosity::Integer, X, y)
     dm = DMatrix(MMI.matrix(X), float(y))
     b = xgboost(dm; kwargs(model, verbosity, model.objective)...)
-    (b, nothing, _getreport(b, model))
+    (b, nothing, (features=_feature_names(X, dm),))
 end
 
 MMI.predict(model::XGBoostAbstractRegressor, fitresult, Xnew) = XGB.predict(fitresult, Xnew)

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -40,6 +40,7 @@ function kwargs(model, silent, seed, objective, eval_metric)
               , subsample = model.subsample
               , colsample_bytree = model.colsample_bytree
               , colsample_bylevel = model.colsample_bylevel
+              , colsample_bynode = model.colsample_bynode
               , lambda = model.lambda
               , alpha = model.alpha
               , tree_method = model.tree_method
@@ -87,6 +88,7 @@ mutable struct XGBoostRegressor <:MMI.Deterministic
     subsample::Float64
     colsample_bytree::Float64
     colsample_bylevel::Float64
+    colsample_bynode::Float64
     lambda::Float64
     alpha::Float64
     tree_method::String
@@ -139,6 +141,7 @@ function XGBoostRegressor(
     ,subsample=1
     ,colsample_bytree=1
     ,colsample_bylevel=1
+    ,colsample_bynode=1
     ,lambda=1
     ,alpha=0
     ,tree_method="auto"
@@ -177,6 +180,7 @@ function XGBoostRegressor(
     ,subsample
     ,colsample_bytree
     ,colsample_bylevel
+    ,colsample_bynode
     ,lambda
     ,alpha
     ,tree_method
@@ -284,6 +288,7 @@ mutable struct XGBoostCount <:MMI.Deterministic
     subsample::Float64
     colsample_bytree::Float64
     colsample_bylevel::Float64
+    colsample_bynode::Float64
     lambda::Float64
     alpha::Float64
     tree_method::String
@@ -336,6 +341,7 @@ function XGBoostCount(
     ,subsample=1
     ,colsample_bytree=1
     ,colsample_bylevel=1
+    ,colsample_bynode=1,
     ,lambda=1
     ,alpha=0
     ,tree_method="auto"
@@ -374,6 +380,7 @@ function XGBoostCount(
     ,subsample
     ,colsample_bytree
     ,colsample_bylevel
+    ,colsample_bynode
     ,lambda
     ,alpha
     ,tree_method
@@ -464,6 +471,7 @@ mutable struct XGBoostClassifier <:MMI.Probabilistic
     subsample::Float64
     colsample_bytree::Float64
     colsample_bylevel::Float64
+    colsample_bynode::Float64
     lambda::Float64
     alpha::Float64
     tree_method::String
@@ -516,6 +524,7 @@ function XGBoostClassifier(
     ,subsample=1
     ,colsample_bytree=1
     ,colsample_bylevel=1
+    ,colsample_bynode=1
     ,lambda=1
     ,alpha=0
     ,tree_method="auto"
@@ -554,6 +563,7 @@ function XGBoostClassifier(
     ,subsample
     ,colsample_bytree
     ,colsample_bylevel
+    ,colsample_bynode
     ,lambda
     ,alpha
     ,tree_method

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -16,7 +16,7 @@ m = machine(model, X, y)
 where
 - `X`: any table of input features whose columns have `Continuous` element scitype; check 
   column scitypes with `schema(X)`.
-- `y`: is an `AbstractVector` continuous target.
+- `y`: is an `AbstractVector` target with `Continuous` elements; check the scitype with `scitype(y)`. 
 
 Train using `fit!(m, rows=...)`.
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -14,7 +14,8 @@ In `MLJ` or `MLJBase`, bind an instance `model` to data with
 m = machine(model, X, y)
 ```
 where
-- `X`: any table of input features, either an `AbstractMatrix` or Tables.jl-compatible table.
+- `X`: any table of input features whose columns have `Continuous` element scitype; check 
+  column scitypes with `schema(X)`.
 - `y`: is an `AbstractVector` continuous target.
 
 Train using `fit!(m, rows=...)`.

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1,0 +1,71 @@
+
+const XGBOOST_DOCS_LINK = "https://xgboost.readthedocs.io/en/stable/index.html"
+const XGBOOST_PARAMS_DOCS_LINK = "https://xgboost.readthedocs.io/en/stable/parameter.html"
+
+
+"""
+$(MMI.doc_header(XGBoostRegressor))
+
+Univariate continuous regression using [xgboost]($XGBOOST_DOCS_LINK).
+
+# Training data
+In `MLJ` or `MLJBase`, bind an instance `model` to data with
+```julia
+m = machine(model, X, y)
+```
+where
+- `X`: any table of input features, either an `AbstractMatrix` or Tables.jl-compatible table.
+- `y`: is an `AbstractVector` continuous target.
+
+Train using `fit!(m, rows=...)`.
+
+# Hyper-parameters
+See $XGBOOST_PARAMS_DOCS_LINK.
+"""
+XGBoostRegressor
+
+
+"""
+$(MMI.doc_header(XGBoostCount))
+
+Univariate discrete regression using [xgboost]($XGBOOST_DOCS_LINK).
+
+# Training data
+In `MLJ` or `MLJBase`, bind an instance `model` to data with
+```julia
+m = machine(model, X, y)
+```
+where
+- `X`: any table of input features, either an `AbstractMatrix` or Tables.jl-compatible table.
+- `y`: is an `AbstractVector` continuous target.
+
+Train using `fit!(m, rows=...)`.
+
+# Hyper-parameters
+See $XGBOOST_PARAMS_DOCS_LINK.
+"""
+XGBoostCount
+
+
+"""
+$(MMI.doc_header(XGBoostClassifier))
+
+Univariate classification using [xgboost]($XGBOOST_DOCS_LINK).
+
+# Training data
+In `MLJ` or `MLJBase`, bind an instance `model` to data with
+```julia
+m = machine(model, X, y)
+```
+where
+- `X`: any table of input features, either an `AbstractMatrix` or Tables.jl-compatible table.
+- `y`: is an `AbstractVector` continuous target.
+
+Train using `fit!(m, rows=...)`.
+
+# Hyper-parameters
+See $XGBOOST_PARAMS_DOCS_LINK.
+"""
+XGBoostClassifier
+
+

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -60,7 +60,7 @@ m = machine(model, X, y)
 ```
 where
 - `X`: any table of input features, either an `AbstractMatrix` or Tables.jl-compatible table.
-- `y`: is an `AbstractVector` continuous target.
+- `y`: is an `AbstractVector` `Finite` target.
 
 Train using `fit!(m, rows=...)`.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,9 +6,9 @@ using Distributions
 import StableRNGs
 rng = StableRNGs.StableRNG(123)
 
-@test_logs (:warn, r"Changing ") XGBoostClassifier(objective="wrong")
-@test_logs (:warn, r"Changing ") XGBoostCount(objective="wrong")
-@test_logs (:warn, r"Your") XGBoostRegressor(objective="binary:logistic")
+@test_logs (:warn, r"Constraint ") XGBoostClassifier(objective="wrong")
+@test_logs (:warn, r"Constraint ") XGBoostCount(objective="wrong")
+@test_logs (:warn, r"Constraint ") XGBoostRegressor(objective="binary:logistic")
 
 @testset "Binary Classification" begin
     plain_classifier = XGBoostClassifier(num_round=100, seed=0)
@@ -27,157 +27,169 @@ rng = StableRNGs.StableRNG(123)
     fit!(m,verbosity = 0)
 end
 
-## REGRESSOR
-plain_regressor = XGBoostRegressor()
-n,m = 10^3, 5 ;
-features = rand(rng, n,m);
-weights = rand(rng, -1:1,m);
-labels = features * weights;
-features = MLJBase.table(features)
-fitresultR, cacheR, reportR = MLJBase.fit(plain_regressor, 0, features, labels);
-rpred = predict(plain_regressor, fitresultR, features);
+@testset "regressor" begin
+    plain_regressor = XGBoostRegressor()
+    (n, m) = (10^3, 5)
+    features = rand(rng, n,m);
+    weights = rand(rng, -1:1,m);
+    labels = features * weights;
+    features = MLJBase.table(features)
+    (fitresultR, cacheR, reportR) = MLJBase.fit(plain_regressor, 0, features, labels)
+    rpred = predict(plain_regressor, fitresultR, features);
+    
+    plain_regressor.objective = "gamma"
+    labels = abs.(labels)
+    fitresultR, cacheR, reportR = MLJBase.fit(plain_regressor, 0, features, labels)
+    rpred = predict(plain_regressor, fitresultR, features);
+    
+    importances = reportR.feature_importances
+    
+    # serialization:
+    serializable_fitresult = MLJBase.save(plain_regressor, fitresultR)
+    
+    restored_fitresult = MLJBase.restore(plain_regressor, serializable_fitresult)
+    @test predict(plain_regressor, restored_fitresult, features) ≈ rpred
+end
 
-plain_regressor.objective = "gamma"
-labels = abs.(labels)
-fitresultR, cacheR, reportR = MLJBase.fit(plain_regressor, 0, features, labels);
-rpred = predict(plain_regressor, fitresultR, features);
+@testset "count" begin
+    count_regressor = XGBoostCount(num_round=10)
+    
+    X = randn(rng, 100, 3) .* randn(rng, 3)'
+    Xtable = table(X)
+    
+    α = 0.1
+    β = [-0.3, 0.2, -0.1]
+    λ = exp.(α .+ X * β)
+    ycount_ = [rand(rng, Poisson(λᵢ)) for λᵢ ∈ λ]
+    ycount = @view(ycount_[:]) # intention is to simulate issue #17
+    
+    fitresultC, cacheC, reportC = MLJBase.fit(count_regressor, 0, Xtable, ycount);
+    fitresultC_, cacheC_, reportC_ = MLJBase.fit(count_regressor, 0, Xtable, ycount_);
+    # the `cacheC` and `reportC` should be same for both models but the 
+    # `fitresultC`s might be different since they may have different pointers to same
+    # information. 
+    @test cacheC == cacheC_
+    @test reportC == reportC_
+    cpred = predict(count_regressor, fitresultC, Xtable);
+    
+    importances = reportC.feature_importances
+end
 
-importances = reportR.feature_importances
+@testset "classifier" begin
+    plain_classifier = XGBoostClassifier(num_round=100, seed=0)
+    
+    # test binary case:
+    N=2
+    X = (x1=rand(rng, 1000), x2=rand(rng, 1000), x3=rand(rng, 1000))
+    ycat = map(X.x1) do x
+        string(mod(round(Int, 10*x), N))
+    end |> categorical
+    y = identity.(ycat) # make plain Vector with categ. elements
+    train, test = partition(eachindex(y), 0.6)
+    fitresult, cache, report = MLJBase.fit(plain_classifier, 0,
+                                                selectrows(X, train), y[train];)
+    yhat = mode.(predict(plain_classifier, fitresult, selectrows(X, test)))
+    misclassification_rate = sum(yhat .!= y[test])/length(test)
+    @test misclassification_rate < 0.015
+    
+    importances = report.feature_importances
+    
+    # Multiclass{10} case:
+    N=10
+    X = (x1=rand(rng, 1000), x2=rand(rng, 1000), x3=rand(rng, 1000))
+    ycat = map(X.x1) do x
+        string(mod(round(Int, 10*x), N))
+    end |> categorical
+    y = identity.(ycat) # make plain Vector with categ. elements
+    
+    train, test = partition(eachindex(y), 0.6)
+    fitresult, cache, report = MLJBase.fit(plain_classifier, 0,
+                                                selectrows(X, train), y[train];)
+    fitresult_, cache_, report_ = MLJBase.fit(
+        plain_classifier, 0, selectrows(X, train), @view(y[train]);
+    ) # mimick issue #17
+    # the `cache` and `report` should be same for both models but the 
+    # `fitresult` might be different since they may have different pointers to same
+    # information. 
+    @test cache == cache_
+    @test report == report_
+    
+    yhat = mode.(predict(plain_classifier, fitresult, selectrows(X, test)))
+    misclassification_rate = sum(yhat .!= y[test])/length(test)
+    @test misclassification_rate < 0.01
+    
+    # check target pool preserved:
+    X = (x1=rand(rng, 400), x2=rand(rng, 400), x3=rand(rng, 400))
+    ycat = vcat(fill('x', 100), fill('y', 100), fill('z', 200)) |>categorical
+    y = identity.(ycat)
+    train, test = partition(eachindex(y), 0.5)
+    @test length(unique(y[train])) == 2
+    @test length(unique(y[test])) == 1
+    fitresult, cache, report = MLJBase.fit(plain_classifier, 0,
+                                                selectrows(X, train), y[train];)
+    yhat = predict_mode(plain_classifier, fitresult, selectrows(X, test))
+    @test Set(MLJBase.classes(yhat[1])) == Set(MLJBase.classes(y[train][1]))
+    
+    # serialization:
+    serializable_fitresult = MLJBase.save(plain_classifier, fitresult)
+    
+    restored_fitresult = MLJBase.restore(plain_classifier, serializable_fitresult)
+    
+    @test predict_mode(plain_classifier, restored_fitresult, selectrows(X, test)) == yhat
+end
 
-# serialization:
-serializable_fitresult =
-    MLJBase.save(plain_regressor, fitresultR);
+# we repeat some of the above for sake of keeping testsets separate
+# could use some generation functions...
+@testset "machine" begin
+    count_regressor = XGBoostCount(num_round=10)
 
-restored_fitresult = MLJBase.restore(plain_regressor,
-                                     serializable_fitresult)
-@test predict(plain_regressor, restored_fitresult, features) ≈ rpred
+    plain_classifier = XGBoostClassifier(num_round=100, seed=0)
+ 
+    X = randn(rng, 100, 3) .* randn(rng, 3)'
+    Xtable = table(X)
+    
+    α = 0.1
+    β = [-0.3, 0.2, -0.1]
+    λ = exp.(α .+ X * β)
+    ycount_ = [rand(rng, Poisson(λᵢ)) for λᵢ ∈ λ]
+    ycount = @view(ycount_[:]) # intention is to simulate issue #17
+   
+    mach = machine(count_regressor, Xtable, ycount)
+    fit!(mach, verbosity=0)
+    yhat = predict(mach, Xtable)
+    
+    # serialize:
+    io = IOBuffer()
+    MLJBase.save(io, mach)
+    
+    # deserialize:
+    seekstart(io)
+    mach2 = machine(io)
+    close(io)
+    
+    # compare:
+    @test predict(mach2, Xtable) ≈ yhat
 
-
-## COUNT
-
-count_regressor = XGBoostCount(num_round=10)
-
-X = randn(rng, 100, 3) .* randn(rng, 3)'
-Xtable = table(X)
-
-α = 0.1
-β = [-0.3, 0.2, -0.1]
-λ = exp.(α .+ X * β)
-ycount_ = [rand(rng, Poisson(λᵢ)) for λᵢ ∈ λ]
-ycount = @view(ycount_[:]) # intention is to simulate issue #17
-
-fitresultC, cacheC, reportC = MLJBase.fit(count_regressor, 0, Xtable, ycount);
-fitresultC_, cacheC_, reportC_ = MLJBase.fit(count_regressor, 0, Xtable, ycount_);
-# the `cacheC` and `reportC` should be same for both models but the 
-# `fitresultC`s might be different since they may have different pointers to same
-# information. 
-@test cacheC == cacheC_
-@test reportC == reportC_
-cpred = predict(count_regressor, fitresultC, Xtable);
-
-importances = reportC.feature_importances
-
-## CLASSIFIER
-
-plain_classifier = XGBoostClassifier(num_round=100, seed=0)
-
-# test binary case:
-N=2
-X = (x1=rand(rng, 1000), x2=rand(rng, 1000), x3=rand(rng, 1000))
-ycat = map(X.x1) do x
-    string(mod(round(Int, 10*x), N))
-end |> categorical
-y = identity.(ycat) # make plain Vector with categ. elements
-train, test = partition(eachindex(y), 0.6)
-fitresult, cache, report = MLJBase.fit(plain_classifier, 0,
-                                            selectrows(X, train), y[train];)
-yhat = mode.(predict(plain_classifier, fitresult, selectrows(X, test)))
-misclassification_rate = sum(yhat .!= y[test])/length(test)
-@test misclassification_rate < 0.015
-
-importances = report.feature_importances
-
-
-# Multiclass{10} case:
-N=10
-X = (x1=rand(rng, 1000), x2=rand(rng, 1000), x3=rand(rng, 1000))
-ycat = map(X.x1) do x
-    string(mod(round(Int, 10*x), N))
-end |> categorical
-y = identity.(ycat) # make plain Vector with categ. elements
-
-train, test = partition(eachindex(y), 0.6)
-fitresult, cache, report = MLJBase.fit(plain_classifier, 0,
-                                            selectrows(X, train), y[train];)
-fitresult_, cache_, report_ = MLJBase.fit(
-    plain_classifier, 0, selectrows(X, train), @view(y[train]);
-) # mimick issue #17
-# the `cache` and `report` should be same for both models but the 
-# `fitresult` might be different since they may have different pointers to same
-# information. 
-@test cache == cache_
-@test report == report_
-
-yhat = mode.(predict(plain_classifier, fitresult, selectrows(X, test)))
-misclassification_rate = sum(yhat .!= y[test])/length(test)
-@test misclassification_rate < 0.01
-
-# check target pool preserved:
-X = (x1=rand(rng, 400), x2=rand(rng, 400), x3=rand(rng, 400))
-ycat = vcat(fill('x', 100), fill('y', 100), fill('z', 200)) |>categorical
-y = identity.(ycat)
-train, test = partition(eachindex(y), 0.5)
-@test length(unique(y[train])) == 2
-@test length(unique(y[test])) == 1
-fitresult, cache, report = MLJBase.fit(plain_classifier, 0,
-                                            selectrows(X, train), y[train];)
-yhat = predict_mode(plain_classifier, fitresult, selectrows(X, test))
-@test Set(MLJBase.classes(yhat[1])) == Set(MLJBase.classes(y[train][1]))
-
-# serialization:
-serializable_fitresult =
-    MLJBase.save(plain_classifier, fitresult)
-
-restored_fitresult = MLJBase.restore(plain_classifier,
-                                     serializable_fitresult)
-
-@test predict_mode(plain_classifier, restored_fitresult, selectrows(X, test)) ==
-    yhat
-
-## MACHINE INTEGRATION
-
-# count regressor (`count_regressor`, `Xtable` and `ycount`
-# defined above):
-
-mach = machine(count_regressor, Xtable, ycount)
-fit!(mach, verbosity=0)
-yhat = predict(mach, Xtable)
-
-# serialize:
-io = IOBuffer()
-MLJBase.save(io, mach)
-
-# deserialize:
-seekstart(io)
-mach2 = machine(io)
-close(io)
-
-# compare:
-@test predict(mach2, Xtable) ≈ yhat
-
-
-# classifier
-mach = machine(plain_classifier, X, y)
-fit!(mach, verbosity=0)
-yhat = predict_mode(mach, X);
-
-# serialize:
-io = IOBuffer()
-MLJBase.save(io, mach)
-
-# deserialize:
-seekstart(io)
-mach2 = machine(io)
-
-# compare:
-@test predict_mode(mach2, X) == yhat
+    N=10
+    X = (x1=rand(rng, 1000), x2=rand(rng, 1000), x3=rand(rng, 1000))
+    ycat = map(X.x1) do x
+        string(mod(round(Int, 10*x), N))
+    end |> categorical
+    yclass = identity.(ycat) # make plain Vector with categ. elements
+    
+    # classifier
+    mach = machine(plain_classifier, X, yclass)
+    fit!(mach, verbosity=0)
+    yhat = predict_mode(mach, X);
+    
+    # serialize:
+    io = IOBuffer()
+    MLJBase.save(io, mach)
+    
+    # deserialize:
+    seekstart(io)
+    mach2 = machine(io)
+    
+    # compare:
+    @test predict_mode(mach2, X) == yhat
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,8 +43,6 @@ end
     fitresultR, cacheR, reportR = MLJBase.fit(plain_regressor, 0, features, labels)
     rpred = predict(plain_regressor, fitresultR, features);
     
-    importances = reportR.feature_importances
-    
     # serialization:
     serializable_fitresult = MLJBase.save(plain_regressor, fitresultR)
     
@@ -72,8 +70,6 @@ end
     @test cacheC == cacheC_
     @test reportC == reportC_
     cpred = predict(count_regressor, fitresultC, Xtable);
-    
-    importances = reportC.feature_importances
 end
 
 @testset "classifier" begin
@@ -92,8 +88,6 @@ end
     yhat = mode.(predict(plain_classifier, fitresult, selectrows(X, test)))
     misclassification_rate = sum(yhat .!= y[test])/length(test)
     @test misclassification_rate < 0.015
-    
-    importances = report.feature_importances
     
     # Multiclass{10} case:
     N=10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,10 @@ using MLJBase
 using Test
 import XGBoost
 using MLJXGBoostInterface
+using MLJTestIntegration
 using Distributions
 import StableRNGs
-rng = StableRNGs.StableRNG(123)
+const rng = StableRNGs.StableRNG(123)
 
 @test_logs (:warn, r"Constraint ") XGBoostClassifier(objective="wrong")
 @test_logs (:warn, r"Constraint ") XGBoostCount(objective="wrong")
@@ -193,3 +194,42 @@ end
     # compare:
     @test predict_mode(mach2, X) == yhat
 end
+
+@testset "generic interface tests" begin
+    @testset "XGBoostRegressor" begin
+        failures, summary = MLJTestIntegration.test(
+            [XGBoostRegressor,],
+            MLJTestIntegration.make_regression()...;
+            mod=@__MODULE__,
+            verbosity=0, # bump to debug
+            throw=false, # set to true to debug
+        )
+        @test isempty(failures)
+    end
+    @testset "XGBoostCount" begin
+        failures, summary = MLJTestIntegration.test(
+            [XGBoostCount],
+            MLJTestIntegration.make_count()...;
+            mod=@__MODULE__,
+            verbosity=0, # bump to debug
+            throw=false, # set to true to debug
+        )
+        @test isempty(failures)
+    end
+    @testset "XGBoostClassifier" begin
+        for data in [
+            MLJTestIntegration.make_binary(),
+            MLJTestIntegration.make_multiclass(),
+        ]
+            failures, summary = MLJTestIntegration.test(
+                [XGBoostClassifier],
+                data...;
+                mod=@__MODULE__,
+                verbosity=0, # bump to debug
+                throw=false, # set to true to debug
+            )
+            @test isempty(failures)
+        end
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,6 +176,9 @@ end
     mach = machine(plain_classifier, X, yclass)
     fit!(mach, verbosity=0)
     yhat = predict_mode(mach, X);
+
+    imps = feature_importances(mach)
+    @test Set(string.([imp[1] for imp ∈ imps])) == Set(["x1", "x2", "x3"])
     
     # serialize:
     io = IOBuffer()


### PR DESCRIPTION
Needs: 

- [x] XGBoost 2.0.1 release

(I haven't tested this yet so I may have a flurry of smaller commits, but I wanted to get this up.)

This PR eliminates most of the code duplication in this package and should make it much easier to maintain.  The main thing that has changed is that each model type is now defined exactly *once* using `Base.@kwdef`.  This duplication could be further limited but I don't want to run afoul of the model interface and this should already be a huge improvement.

~~Furthermore, all model arguments with the exception of `num_round` (which has now default defined by xgboost) now accept `nothing` as an argument which means that they will use the built-in default.  This eliminates the need for manually syncing default parameters between models and with xgboost itself.~~