### PR TITLE
fixed mistakenly redundant human_name methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJXGBoostInterface"
 uuid = "54119dfa-1dab-4055-a167-80440f4f7a91"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -216,12 +216,12 @@ MMI.human_name(::Type{<:XGBoostRegressor}) = "eXtreme Gradient Boosting Regresso
 MMI.load_path(::Type{<:XGBoostCount}) = "$PKG.XGBoostCount"
 MMI.input_scitype(::Type{<:XGBoostCount}) = Table(Continuous)
 MMI.target_scitype(::Type{<:XGBoostCount}) = AbstractVector{Count}
-MMI.human_name(::Type{<:XGBoostRegressor}) = "eXtreme Gradient Boosting Count Regressor"
+MMI.human_name(::Type{<:XGBoostCount}) = "eXtreme Gradient Boosting Count Regressor"
 
 MMI.load_path(::Type{<:XGBoostClassifier}) = "$PKG.XGBoostClassifier"
 MMI.input_scitype(::Type{<:XGBoostClassifier}) = Table(Continuous)
 MMI.target_scitype(::Type{<:XGBoostClassifier}) = AbstractVector{<:Finite}
-MMI.human_name(::Type{<:XGBoostRegressor}) = "eXtreme Gradient Boosting Classifier"
+MMI.human_name(::Type{<:XGBoostClassifier}) = "eXtreme Gradient Boosting Classifier"
 
 
 include("docstrings.jl")


### PR DESCRIPTION
This fixes that I somehow mistakenly wrote `human_name` for all the same model type rather than what they were supposed to be written for.