### PR TITLE
watchlist arguments should respect verbosity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJXGBoostInterface"
 uuid = "54119dfa-1dab-4055-a167-80440f4f7a91"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -105,6 +105,9 @@ function kwargs(model, verbosity, obj)
     fn = filter(∉(excluded), fieldnames(typeof(model)))
     o = NamedTuple(n=>getfield(model, n) for n ∈ fn if !isnothing(getfield(model, n)))
     o = merge(o, (silent=(verbosity ≤ 0),))
+    # watchlist is for log output, so override if it's default and verbosity ≤ 0
+    wl = (verbosity ≤ 0 && isnothing(model.watchlist)) ? (;) : model.watchlist
+    o = merge(o, (watchlist=wl,))
     merge(o, (objective=_fix_objective(obj),))
 end
 


### PR DESCRIPTION
This fixes #23.

At first I couldn't understand how I could possibly have missed this since indeed it makes testing this package much nicer because it silences all of the annoying output, but then I realized that it's because the old XGBoost.jl didn't provide a good way of doing this and after my overhaul got merged I simply forgot about the whole thing.