### PR TITLE
disable parameter validation by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJXGBoostInterface"
 uuid = "54119dfa-1dab-4055-a167-80440f4f7a91"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -92,6 +92,9 @@ function modelexpr(name::Symbol, absname::Symbol, obj::AbstractString, objvalida
             nthread::Int = Base.Threads.nthreads()::(_ ≥ 0)
             importance_type::String = "gain"
             seed::Union{Int,Nothing} = nothing  # nothing will use built in default
+            # this should probably be fixed so that we don't pass invalid parameters,
+            # but in the meantime, let's just disable checking
+            validate_parameters::Bool = false
         end
 
     end


### PR DESCRIPTION
Recently we changed XGBoost.jl so that it warns on invalid parameters by default (and fixed logging so that it goes through the Julia logger).

I really should have made sure this omitted most parameters when I overhauled it in the first place, but the way MLJ model objects work isn't exactly conducive to doing that.

This is admittedly a half-assed fix, but it will prevent users from unnecessarily getting bombarded with invalid parameter warnings.