### PR TITLE
added some more tests

### DIFF
--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -114,23 +114,22 @@ function kwargs(model, verbosity, obj)
     merge(o, (objective=_fix_objective(obj),))
 end
 
-function MMI.feature_importances(model::XGTypes, (booster, _), (features,))
+function MMI.feature_importances(model::XGTypes, (booster, _), r)
     dict = XGB.importance(booster, model.importance_type)
     if length(last(first(dict))) > 1
-        [features[k] => zero(first(v)) for (k, v) in dict]
+        [r.features[k] => zero(first(v)) for (k, v) in dict]
     else
-        [features[k] => first(v) for (k, v) in dict]
+        [r.features[k] => first(v) for (k, v) in dict]
     end
 end
 
 function _feature_names(X, dmatrix)
     schema = Tables.schema(X)
      if schema === nothing
-        features = [Symbol("x$j") for j in 1:ncols(dmatrix)]
+        [Symbol("x$j") for j in 1:ncols(dmatrix)]
     else
-        features = schema.names |> collect
+        schema.names |> collect
     end
-    return features
 end
 
 function MMI.fit(model::XGBoostAbstractRegressor, verbosity::Integer, X, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,9 @@ end
 
     restored_fitresult = MLJBase.restore(plain_regressor, serializable_fitresult)
     @test predict(plain_regressor, restored_fitresult, features) ≈ rpred
+
+    imps = feature_importances(plain_regressor, fitresultR, reportR)
+    @test Set(string.([imp[1] for imp ∈ imps])) == Set(string.(("x",), 1:5))
 end
 
 @testset "count" begin
@@ -70,6 +73,13 @@ end
     @test cacheC == cacheC_
     @test reportC == reportC_
     cpred = predict(count_regressor, fitresultC, Xtable);
+
+    imps = feature_importances(count_regressor, fitresultC, reportC)
+    @test Set(string.([imp[1] for imp ∈ imps])) == Set(string.(("x",), 1:3))
+
+    ser = MLJBase.save(count_regressor, fitresultC)
+    restored_fitresult = MLJBase.restore(count_regressor, ser)
+    @test predict(count_regressor, restored_fitresult, Xtable) ≈ cpred
 end
 
 @testset "classifier" begin
@@ -178,7 +188,7 @@ end
     yhat = predict_mode(mach, X);
 
     imps = feature_importances(mach)
-    @test Set(string.([imp[1] for imp ∈ imps])) == Set(["x1", "x2", "x3"])
+    @test Set(string.([imp[1] for imp ∈ imps])) == Set(string.(("x",), 1:3))
 
     # serialize:
     io = IOBuffer()


### PR DESCRIPTION
All 3 model types should now be covered for both serialization and feature importance.

The "report" argument to `feature_importances` no longer uses automatic destructuring, this is because I got confused about the fact that it is returned as a `NamedTuple` but destructured as a `Tuple`.