### PR TITLE
Loosen test thresholds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 [compat]
 MLJModelInterface = "1.5"
 Tables = "1.0.5"
-XGBoost = "2.0.1 - 2.3.2"
+XGBoost = "2.0.1"
 julia = "1.6"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,7 +97,7 @@ end
                                                 selectrows(X, train), y[train];)
     yhat = mode.(predict(plain_classifier, fitresult, selectrows(X, test)))
     misclassification_rate = sum(yhat .!= y[test])/length(test)
-    @test misclassification_rate < 0.015
+    @test misclassification_rate < 0.025
 
     # Multiclass{10} case:
     N=10
@@ -121,7 +121,7 @@ end
 
     yhat = mode.(predict(plain_classifier, fitresult, selectrows(X, test)))
     misclassification_rate = sum(yhat .!= y[test])/length(test)
-    @test misclassification_rate < 0.01
+    @test misclassification_rate < 0.03
 
     # check target pool preserved:
     X = (x1=rand(rng, 400), x2=rand(rng, 400), x3=rand(rng, 400))


### PR DESCRIPTION
Fixes https://github.com/JuliaAI/MLJXGBoostInterface.jl/issues/43.

@ExpandingMan was there any reason for choosing exactly these thresholds that I now have changed?

Thanks @tylerjthomas9 for your comment (https://github.com/JuliaAI/MLJXGBoostInterface.jl/issues/43#issuecomment-1751513611). It's very useful to know that

> I think the change to `hist` as the default tree method in libxgboost v2 is causing the test failures. Changing the default `tree_method="exact"` causes all the tests to pass.

So as long as @ExpandingMan does not have any objections, I think we can move forward with just loosening the thresholds. I find it always a bit strange with statistical models that non-breaking changes can affect model performance a lot, but I also wouldn't want to force model authors to call every little model change breaking.