### PR TITLE
Remove compat restrictions again

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJXGBoostInterface"
 uuid = "54119dfa-1dab-4055-a167-80440f4f7a91"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
@@ -12,7 +12,7 @@ XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 [compat]
 MLJModelInterface = "1.5"
 Tables = "1.0.5"
-XGBoost = "2.0.1 - 2.4.1"
+XGBoost = "2.0.1"
 julia = "1.6"
 
 [extras]

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -107,12 +107,15 @@ eval(modelexpr(:XGBoostRegressor, :XGBoostAbstractRegressor, "reg:squarederror",
 function kwargs(model, verbosity, obj)
     excluded = [:importance_type]
     fn = filter(∉(excluded), fieldnames(typeof(model)))
-    o = NamedTuple(n=>getfield(model, n) for n ∈ fn if !isnothing(getfield(model, n)))
-    o = merge(o, (silent=(verbosity ≤ 0),))
+    out = NamedTuple(n=>getfield(model, n) for n ∈ fn if !isnothing(getfield(model, n)))
+    out = merge(out, (silent=(verbosity ≤ 0),))
     # watchlist is for log output, so override if it's default and verbosity ≤ 0
     wl = (verbosity ≤ 0 && isnothing(model.watchlist)) ? (;) : model.watchlist
-    isnothing(wl) || (o = merge(o, (watchlist=wl,)))
-    merge(o, (objective=_fix_objective(obj),))
+    if !isnothing(wl)
+        out = merge(out, (watchlist=wl,))
+    end
+    out = merge(out, (objective=_fix_objective(obj),))
+    return out
 end
 
 function MMI.feature_importances(model::XGTypes, (booster, _), r)


### PR DESCRIPTION
Fixes #46 and closes #49. This is PR is a permanent fix after the hotfix in #47.

In hindsight, I should have checked with XGBoost first to let them make a patch. My bad. This PR basically reverts https://github.com/JuliaAI/MLJXGBoostInterface.jl/pull/47.

@ablaom I renamed `o` to `out` because that appears to be the intention of that variable. I hope that's okay.