### PR TITLE
Expose monotone_constraints for use in XGBoostRegressor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
+      - uses: julia-actions/cache@v1
         env:
           cache-name: cache-artifacts
         with:

--- a/src/MLJXGBoostInterface.jl
+++ b/src/MLJXGBoostInterface.jl
@@ -97,6 +97,7 @@ function modelexpr(name::Symbol, absname::Symbol, obj::AbstractString, objvalida
             # but in the meantime, let's just disable checking
             validate_parameters::Bool = false
             eval_metric::Vector{String} = String[]
+            monotone_constraints::Union{Nothing,String} = nothing
         end
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,37 @@ end
     rpred_noES = predict(es_regressor, fitresultR, features);
     @test abs(mean(abs.(rpred-mod_labels))) < abs(mean(abs.(rpred_noES-mod_labels)))
     @test ismissing(fitresultR[1].best_iteration)
+
+
+    # Create synthetic data with 3 features
+    n = 200
+    X = (x1 = randn(n), x2 = randn(n), x3 = randn(n))
+    
+    # Target: positively dependent on all features
+    y = 2 .* X.x1 .+ 3 .* X.x2 .+ 1.5 .* X.x3 .+ 0.1 .* randn(n)
+
+    X_tbl = MLJBase.table(X)
+
+    # Model with negative monotone constraints
+    model_neg = XGBoostRegressor(num_round=20, monotone_constraints="(-1,-1,-1)")
+    mach_neg = machine(model_neg, X_tbl, y)
+    fit!(mach_neg, verbosity=0)
+    yhat_neg = predict(mach_neg, X_tbl)
+
+    # Model with positive monotone constraints (should perform better)
+    model_pos = XGBoostRegressor(num_round=20, monotone_constraints="(1,1,1)")
+    mach_pos = machine(model_pos, X_tbl, y)
+    fit!(mach_pos, verbosity=0)
+    yhat_pos = predict(mach_pos, X_tbl)
+
+    rmse = (ŷ, y) -> sqrt(mean((ŷ .- y).^2))
+    rmse_neg = rmse(yhat_neg, y)
+    rmse_pos = rmse(yhat_pos, y)
+
+    @test rmse_neg > 2 * rmse_pos
+
+    @test mach_pos.model.monotone_constraints == "(1,1,1)"
+    @test mach_neg.model.monotone_constraints == "(-1,-1,-1)"
 end
 
 @testset "count" begin
@@ -239,6 +270,9 @@ end
     @testset "Default Early Stopping Params" begin
         @test XGBoostRegressor().early_stopping_rounds == 0
     end
+    @testset "Default monotone constraints" begin
+        @test isnothing(XGBoostRegressor().monotone_constraints)
+    end
     @testset "XGBoostRegressor" begin
         failures, summary = MLJTestInterface.test(
             [XGBoostRegressor,],
@@ -275,3 +309,4 @@ end
         end
     end
 end
+


### PR DESCRIPTION
The monotone_constraints::Union{Nothing, String} field has been added to the model structs.

The constraint string (e.g. "(1,0,-1)") is passed directly to the XGBoost.Booster parameters when present.

A new testset "xgboost monotone_constraints" has been added using synthetic data with a known monotonic relationship.

See: https://xgboost.readthedocs.io/en/latest/tutorials/monotonic.html

